### PR TITLE
pin zigwin32 HEAD version and change module name

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
 
-    const zigwin32 = b.dependency("zigwin32", .{}).module("zigwin32");
+    const zigwin32 = b.dependency("zigwin32", .{}).module("win32");
     const known_folders = b.dependency("known_folders", .{}).module("known-folders");
 
     const use_shm_funcs = b.option(
@@ -30,7 +30,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .link_libc = use_shm_funcs,
     });
-
 
     const options = b.addOptions();
     options.addOption(bool, "use_shm_funcs", use_shm_funcs);

--- a/build.zig
+++ b/build.zig
@@ -57,4 +57,10 @@ pub fn build(b: *std.Build) void {
 
     const check = b.step("check", "Check if tests compiles");
     check.dependOn(&unit_test_check.step);
+
+    _ = b.addModule("shared_memory", .{
+        .root_source_file = b.path("src/shared_memory.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{ .name = .shared_memory, .version = "0.1.0", .dependencies = .{
     .zigwin32 = .{
-        .url = "https://github.com/marlersoft/zigwin32/archive/refs/heads/main.zip",
-        .hash = "12205354832d93fb0b7f5f3a55965afd52f9c631e5f57d26f35f0ef18c8ceafa9260",
+        .url = "https://github.com/marlersoft/zigwin32/archive/7b434a47c2b85f395d8e5a6dca47af6a74422521.zip",
+        .hash = "zigwin32-25.0.28-preview-AAAAALqY-wMp_N2rd4U4tD9LAxh0TbUPLKhzx6lngGQK",
     },
     .known_folders = .{
         .url = "git+https://github.com/ziglibs/known-folders.git#aa24df42183ad415d10bc0a33e6238c437fc0f59",


### PR DESCRIPTION
I'm not sure if "pin" is the correct way to name this, but... I've just added commit info in the `.url` of `zigwin32` package, so if HEAD changes compiler won't complain. 
Also it seems the module has changed to `win32`.  Hope it helps.